### PR TITLE
feat: add push url support and deferred annotations

### DIFF
--- a/buckaroo/builders/base_builder.py
+++ b/buckaroo/builders/base_builder.py
@@ -20,6 +20,8 @@ class BaseBuilder(ABC):
         self._return_url_error: Optional[str] = None
         self._return_url_reject: Optional[str] = None
         self._continue_on_incomplete: str = "1"
+        self._push_url: Optional[str] = None
+        self._push_url_failure: Optional[str] = None
         self._client_ip: Optional[ClientIP] = None
         self._service_parameters: List[Parameter] = []
         self._payload: Dict[str, Any] = {}  # Store original payload
@@ -70,6 +72,16 @@ class BaseBuilder(ABC):
         self._continue_on_incomplete = continue_incomplete
         return self
     
+    def push_url(self, url: str) -> 'BaseBuilder':
+        """Set the Push (webhook) URL."""
+        self._push_url = url
+        return self
+
+    def push_url_failure(self, url: str) -> 'BaseBuilder':
+        """Set the Push URL for failure notifications."""
+        self._push_url_failure = url
+        return self
+
     def client_ip(self, ip_address: str, ip_type: int = 0) -> 'BaseBuilder':
         """Set the client IP information."""
         self._client_ip = ClientIP(type=ip_type, address=ip_address)
@@ -194,7 +206,12 @@ class BaseBuilder(ABC):
             
         if 'continue_on_incomplete' in data:
             self.continue_on_incomplete(data['continue_on_incomplete'])
-            
+
+        if 'push_url' in data:
+            self.push_url(data['push_url'])
+        if 'push_url_failure' in data:
+            self.push_url_failure(data['push_url_failure'])
+
         if 'client_ip' in data:
             client_ip_data = data['client_ip']
             if isinstance(client_ip_data, str):
@@ -311,6 +328,8 @@ class BaseBuilder(ABC):
             return_url_error=self._return_url_error,
             return_url_reject=self._return_url_reject,
             continue_on_incomplete=self._continue_on_incomplete,
+            push_url=self._push_url,
+            push_url_failure=self._push_url_failure,
             client_ip=self._client_ip,
             services=service_list
         )

--- a/buckaroo/builders/payments/capabilities/authorize_capture_capable.py
+++ b/buckaroo/builders/payments/capabilities/authorize_capture_capable.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 """
 Payment capability mixins for specific payment features.

--- a/buckaroo/builders/payments/capabilities/bank_transfer_capabilities.py
+++ b/buckaroo/builders/payments/capabilities/bank_transfer_capabilities.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 """
 Payment capability mixins for specific payment features.

--- a/buckaroo/builders/payments/capabilities/encrypted_pay_capable.py
+++ b/buckaroo/builders/payments/capabilities/encrypted_pay_capable.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 """
 Payment capability mixins for specific payment features.

--- a/buckaroo/builders/payments/capabilities/fast_checkout_capable.py
+++ b/buckaroo/builders/payments/capabilities/fast_checkout_capable.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 """
 Payment capability mixins for specific payment features.

--- a/buckaroo/builders/payments/capabilities/instant_refund_capable.py
+++ b/buckaroo/builders/payments/capabilities/instant_refund_capable.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 """
 Payment capability mixins for specific payment features.

--- a/buckaroo/builders/payments/credit_card_builder.py
+++ b/buckaroo/builders/payments/credit_card_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 
 from buckaroo.builders.payments.capabilities.encrypted_pay_capable import EncryptedPayCapable

--- a/buckaroo/builders/payments/ideal_builder.py
+++ b/buckaroo/builders/payments/ideal_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 from .payment_builder import PaymentBuilder
 from .capabilities.bank_transfer_capabilities import BankTransferCapabilities

--- a/buckaroo/builders/payments/ideal_qr_builder.py
+++ b/buckaroo/builders/payments/ideal_qr_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 from .payment_builder import PaymentBuilder
 

--- a/buckaroo/builders/payments/klarnakp_builder.py
+++ b/buckaroo/builders/payments/klarnakp_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 
 from buckaroo.models.payment_response import PaymentResponse

--- a/buckaroo/builders/payments/paybybank_builder.py
+++ b/buckaroo/builders/payments/paybybank_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 from .payment_builder import PaymentBuilder
 from .capabilities.bank_transfer_capabilities import BankTransferCapabilities

--- a/buckaroo/builders/payments/payconiq_builder.py
+++ b/buckaroo/builders/payments/payconiq_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 from .payment_builder import PaymentBuilder
 from .capabilities.bank_transfer_capabilities import BankTransferCapabilities

--- a/buckaroo/builders/payments/payment_builder.py
+++ b/buckaroo/builders/payments/payment_builder.py
@@ -1,5 +1,7 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from ..base_builder import BaseBuilder
+from ...models.payment_request import ClientIP, Parameter, PaymentRequest, Service, ServiceList
+from ...models.payment_response import PaymentResponse
 
 
 class PaymentBuilder(BaseBuilder):
@@ -177,7 +179,12 @@ class PaymentBuilder(BaseBuilder):
             
         if 'continue_on_incomplete' in data:
             self.continue_on_incomplete(data['continue_on_incomplete'])
-            
+
+        if 'push_url' in data:
+            self.push_url(data['push_url'])
+        if 'push_url_failure' in data:
+            self.push_url_failure(data['push_url_failure'])
+
         if 'client_ip' in data:
             client_ip_data = data['client_ip']
             if isinstance(client_ip_data, str):
@@ -276,6 +283,8 @@ class PaymentBuilder(BaseBuilder):
             return_url_error=self._return_url_error,
             return_url_reject=self._return_url_reject,
             continue_on_incomplete=self._continue_on_incomplete,
+            push_url=self._push_url,
+            push_url_failure=self._push_url_failure,
             client_ip=self._client_ip,
             services=service_list
         )

--- a/buckaroo/builders/payments/sofort_builder.py
+++ b/buckaroo/builders/payments/sofort_builder.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Dict, Any
 from .payment_builder import PaymentBuilder
 from .capabilities.bank_transfer_capabilities import BankTransferCapabilities

--- a/buckaroo/models/payment_request.py
+++ b/buckaroo/models/payment_request.py
@@ -83,6 +83,8 @@ class PaymentRequest:
     return_url_error: str
     return_url_reject: str
     continue_on_incomplete: str = "1"
+    push_url: Optional[str] = None
+    push_url_failure: Optional[str] = None
     client_ip: Optional[ClientIP] = None
     services: Optional[ServiceList] = None
     
@@ -104,7 +106,12 @@ class PaymentRequest:
             "ReturnURLReject": self.return_url_reject,
             "ContinueOnIncomplete": self.continue_on_incomplete,
         }
-        
+
+        if self.push_url:
+            request_dict["PushURL"] = self.push_url
+        if self.push_url_failure:
+            request_dict["PushURLFailure"] = self.push_url_failure
+
         if self.client_ip:
             request_dict["ClientIP"] = self.client_ip.to_dict()
             


### PR DESCRIPTION
- add push_url and push_url_failure (webhook URLs) to BaseBuilder, PaymentBuilder, and PaymentRequest
- conditionally serialize PushURL/PushURLFailure in request dict to avoid sending null keys
- add `from __future__ import annotations` to capability mixins and builders to fix NameError from forward-referenced `self: 'PaymentBuilder'` type hints used with TYPE_CHECKING conditional imports