### PR TITLE
feat: add confirm_credential and register billink builder

### DIFF
--- a/buckaroo/_buckaroo_client.py
+++ b/buckaroo/_buckaroo_client.py
@@ -110,6 +110,21 @@ class BuckarooClient(object):
         """
         return self.config.api_endpoint
     
+    def confirm_credential(self) -> bool:
+        """
+        Verify that the configured store key and secret key are valid.
+        
+        Calls the Transaction Specification endpoint which requires HMAC authentication.
+        
+        Returns:
+            bool: True if credentials are valid, False otherwise.
+        """
+        try:
+            response = self.http_client.get('/json/Transaction/Specification/ideal')
+            return response.success
+        except Exception:
+            return False
+    
     def get_config_info(self) -> dict:
         """
         Get configuration information.

--- a/buckaroo/builders/payments/billink_builder.py
+++ b/buckaroo/builders/payments/billink_builder.py
@@ -1,0 +1,21 @@
+from typing import Dict, Any
+from .payment_builder import PaymentBuilder
+
+class BillinkBuilder(PaymentBuilder):
+    """Builder for Billink payments with buy-now-pay-later capabilities."""
+
+    def get_service_name(self) -> str:
+        """Get the service name for Billink payments."""
+        return "billink"
+
+    def get_allowed_service_parameters(self, action: str = "Pay") -> Dict[str, Any]:
+        """Get the allowed service parameters for Billink payments based on action."""
+
+        if action.lower() in ["pay"]:
+            return {
+                "billingCustomer": {"type": list, "required": True, "description": "Billing customer information"},
+                "shippingCustomer": {"type": list, "required": True, "description": "Shipping customer information"},
+                "article": {"type": list, "required": True, "description": "Billink articles"},
+            }
+
+        return {}

--- a/buckaroo/factories/payment_method_factory.py
+++ b/buckaroo/factories/payment_method_factory.py
@@ -19,6 +19,7 @@ from buckaroo.builders.payments.google_pay_builder import GooglePayBuilder
 from buckaroo.builders.payments.ideal_qr_builder import IdealQrBuilder
 from buckaroo.builders.payments.in3_builder import In3Builder
 from buckaroo.builders.payments.kbc_builder import KBCBuilder
+from buckaroo.builders.payments.billink_builder import BillinkBuilder
 from buckaroo.builders.payments.klarna_builder import KlarnaBuilder
 from buckaroo.builders.payments.klarnakp_builder import KlarnaKPBuilder
 from buckaroo.builders.payments.knaken_builder import KnakenBuilder
@@ -51,6 +52,7 @@ class PaymentMethodFactory(BuilderFactory):
         "bancontact": BancontactBuilder,
         "belfius": BelfiusBuilder,
         "bizum": BizumBuilder,
+        "billink": BillinkBuilder,
         "blik": BlikBuilder,
         "buckaroovoucher": BuckarooVoucherBuilder,
         "clicktopay": ClickToPayBuilder,
@@ -176,19 +178,6 @@ class PaymentMethodFactory(BuilderFactory):
                 service_name = service.get('Name', '').lower()
                 if service_name in cls._payment_methods:
                     return service_name
-                
-                # Map known service names to payment methods
-                service_mapping = {
-                    'alipay': 'alipay',
-                    'applepay': 'applepay',
-                    'ideal': 'ideal', 
-                    'creditcard': 'creditcard',
-                    'sofort': 'sofort',
-                    'payconiq': 'payconiq'
-                }
-                
-                if service_name in service_mapping:
-                    return service_mapping[service_name]
             
         # Default fallback - could be configurable
         logging.warning(


### PR DESCRIPTION
- Add `confirm_credential()` to BuckarooClient for API credential validation
- Register BillinkBuilder in PaymentMethodFactory
- Remove redundant service_mapping in detect_method_from_payload (already covered by _payment_methods lookup)