### PR TITLE
BTI-715: support optional In3 CompanyName & CocNumber params

### DIFF
--- a/examples/in3.py
+++ b/examples/in3.py
@@ -31,6 +31,13 @@ def demo_pay() -> None:
 
     try:
         app = Buckaroo.from_env()
+
+        # CompanyName and CocNumber are optional billingCustomer fields for B2B
+        # orders. They ride along in the billingCustomer group; omit them for
+        # regular consumer payments.
+        billing = _customer()
+        billing.update({"CompanyName": "Acme B.V.", "CocNumber": "12345678"})
+
         response = app.payments.create_payment(
             "in3",
             {
@@ -46,7 +53,7 @@ def demo_pay() -> None:
                     "article": [
                         {"Description": "Widget", "Quantity": "2", "GrossUnitPrice": "125.00"},
                     ],
-                    "billingCustomer": [_customer()],
+                    "billingCustomer": [billing],
                     "shippingCustomer": [_customer()],
                 },
             },

--- a/tests/feature/payments/test_in3.py
+++ b/tests/feature/payments/test_in3.py
@@ -26,6 +26,47 @@ class TestIn3Feature:
             },
         )
 
+    def test_in3_pay_with_company_and_coc_flows_through_billing_customer(
+        self, buckaroo, mock_strategy
+    ):
+        """Optional B2B fields CompanyName and CocNumber (BTI-715) ride along in
+        the billingCustomer group on the regular In3 Pay flow, reaching the wire
+        as GroupType=Billingcustomer, GroupID=1.
+        """
+        Helpers.assert_pay_returns_pending_with_redirect(
+            buckaroo,
+            mock_strategy,
+            method="in3",
+            invoice="INV-IN3-005",
+            payload_overrides={"amount": 25.00, "description": "Test in3 B2B pay"},
+            service_params={
+                "article": [
+                    {"description": "Widget", "quantity": "2", "GrossUnitPrice": "12.50"},
+                ],
+                "billingCustomer": [
+                    {
+                        "firstName": "John",
+                        "lastName": "Doe",
+                        "CompanyName": "Acme B.V.",
+                        "CocNumber": "12345678",
+                    },
+                ],
+                "shippingCustomer": [
+                    {"firstName": "John", "lastName": "Doe"},
+                ],
+            },
+        )
+
+        billing = {
+            param["Name"]: param
+            for param in recorded_service_parameters(mock_strategy)
+            if param["GroupType"] == "Billingcustomer"
+        }
+        assert billing["Companyname"]["Value"] == "Acme B.V."
+        assert billing["Cocnumber"]["Value"] == "12345678"
+        assert billing["Companyname"]["GroupID"] == "1"
+        assert billing["Cocnumber"]["GroupID"] == "1"
+
     def test_in3_authorize_returns_pending_with_redirect(self, buckaroo, mock_strategy):
         def add_service_params(builder):
             builder.add_parameter("route", "AbnB2b")


### PR DESCRIPTION
- In3 accepts two optional B2B billingCustomer fields, `CompanyName` and `CocNumber`. They already flow through the SDK's `billingCustomer` list-group; no SDK code change was needed.
- Adds a feature test asserting both fields reach the wire on the **Pay** flow as `GroupType=Billingcustomer`, `GroupID=1`.
- Adds the two fields to the Pay demo in the In3 example so the usage is discoverable (BTI-637).
- Verified against the Buckaroo **test** gateway: no parameter errors for these fields; the gateway accepts them.