### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Released]
 
+## [1.1.0]
+- BTI-16 Add solution: Split Payments
+- BTI-17 Add solution: PayPerEmail
+- BTI-20 Add verification method: iDIN
+- BTI-21 Add solution: Instant Refunds
+- BTI-22 Add solution: Credit Management
+- BTI-23 Add solution: Emandate
+
 ## [0.2.0]
 - BTI-977 Add Point of Sale (POS) payment method
 - BTI-22 Add Credit Management solution

--- a/README.md
+++ b/README.md
@@ -407,9 +407,7 @@ response = app.solutions.create_solution(
 ).create_payment_plan()
 
 # InvoiceInfo - invoice is required, top-level
-response = app.solutions.create_solution(
-    "creditmanagement", {"invoice": "INV-001"}
-).invoice_info()
+response = app.solutions.create_solution("creditmanagement", {"invoice": "INV-001"}).invoice_info()
 ```
 
 `create_combined_invoice` accepts the same invoice service fields as `create_invoice`, including the `Debtor` group. A combined request has a single shared top level, so `invoice` and `currency` are set on the *funding* payment rather than on the CreditManagement3 sub-builder:

--- a/buckaroo/_version.py
+++ b/buckaroo/_version.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.0"
+VERSION = "1.1.0"

--- a/buckaroo/config/buckaroo_config.py
+++ b/buckaroo/config/buckaroo_config.py
@@ -62,7 +62,7 @@ class BuckarooConfig:
     logging_enabled: bool = True
     verify_ssl: bool = True
     custom_endpoint: Optional[str] = None
-    user_agent: str = "BuckarooSDK-Python/1.0.0"
+    user_agent: str = "BuckarooSDK-Python/1.1.0"
     max_redirects: int = 5
 
     def __post_init__(self):

--- a/tests/unit/config/test_buckaroo_config.py
+++ b/tests/unit/config/test_buckaroo_config.py
@@ -44,7 +44,7 @@ def test_defaults():
     assert cfg.logging_enabled is True
     assert cfg.verify_ssl is True
     assert cfg.custom_endpoint is None
-    assert cfg.user_agent == "BuckarooSDK-Python/1.0.0"
+    assert cfg.user_agent == "BuckarooSDK-Python/1.1.0"
     assert cfg.max_redirects == 5
 
 

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -9,7 +9,7 @@ def test_version_attribute_matches_version_module():
     from buckaroo import _version
 
     assert buckaroo.__version__ == _version.VERSION
-    assert buckaroo.__version__ == "1.0.0"
+    assert buckaroo.__version__ == "1.1.0"
 
 
 def test_public_api_reexports():
@@ -49,4 +49,4 @@ def test_setup_py_can_read_version_module():
     version_file = Path(buckaroo.__file__).parent / "_version.py"
     namespace = runpy.run_path(str(version_file))
 
-    assert namespace["VERSION"] == "1.0.0"
+    assert namespace["VERSION"] == "1.1.0"


### PR DESCRIPTION
BTI-1307 — Python SDK | Update, Test & Release 1.1.0

## Changelog

- BTI-16 Add solution: Split Payments
- BTI-17 Add solution: PayPerEmail
- BTI-20 Add verification method: iDIN
- BTI-21 Add solution: Instant Refunds
- BTI-22 Add solution: Credit Management
- BTI-23 Add solution: Emandate

## Changes in this PR

- Bump `VERSION` and the SDK user agent to `1.1.0`
- Add the `[1.1.0]` entry to `CHANGELOG.md`
- Reformat one README code block so `ruff format --check` passes

## Notes

The features listed above were already merged into `develop` and shipped in the `v1.0.0` tag. This PR formally releases them under `1.1.0` as described in BTI-1307.

Tests: 2507 passed. Ruff check + format: clean.